### PR TITLE
Fixes national comparison box disappearance

### DIFF
--- a/hackathon-app/src/components/plots/ComparisonBarPlot.jsx
+++ b/hackathon-app/src/components/plots/ComparisonBarPlot.jsx
@@ -16,9 +16,6 @@ export default function ComparisonBarPlot({
 	metric,
 	getComparison,
 }) {
-	// Hide for national level (nothing to compare against)
-	if (level === 'national') return null;
-
 	const { ukAvg, selected, delta } = getComparison({
 		level,
 		quarter,
@@ -26,14 +23,20 @@ export default function ComparisonBarPlot({
 		metric,
 	});
 
-	// Debug (remove once happy)
-	// console.log('COMPARE', { level, quarter, geography, metric, ukAvg, selected, delta });
-
 	if (ukAvg == null || selected == null) {
 		return (
 			<div className='bg-white/70 rounded-2xl shadow p-4'>
 				<h2 className='font-semibold mb-2'>{title}</h2>
 				<div className='text-sm opacity-70'>No comparison data available.</div>
+			</div>
+		);
+	}
+
+	if (level === 'national') {
+		return (
+			<div className='bg-white/70 rounded-2xl shadow p-4'>
+				<h2 className='font-semibold mb-2'>{title}</h2>
+				<div className='text-sm opacity-70'>Cannot show comparison for national level.</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
Previously, the comparison bar plot component would entirely disappear when the national level was selected. This change prevents the component from completely vanishing by displaying an informative message ("Cannot show comparison for national level") instead.

This improves the user experience by providing clear feedback on why a comparison cannot be shown at the national level.