### PR TITLE
Refines plot legend layout

### DIFF
--- a/hackathon-app/src/components/plots/LonelinessStackedBar.jsx
+++ b/hackathon-app/src/components/plots/LonelinessStackedBar.jsx
@@ -105,14 +105,15 @@ export default function LonelinessStackedBar({
 						},
 						yaxis: { title: 'Percentage (%)', automargin: true },
 						autosize: true,
-						margin: { t: 40, r: 16, b: 90, l: 52 }, // extra bottom for rotated labels
+						margin: { t: 85, r: 16, b: 85, l: 52 }, // more top space for legend
 						legend: {
 							orientation: 'h',
 							x: 0,
 							xanchor: 'left',
-							y: 1.15,
+							y: 1.4, // lift slightly
 							yanchor: 'top',
-							font: { size: 10 },
+							font: { size: 9 },
+							tracegroupgap: 6, // a bit more breathing room if it wraps
 						},
 						dragmode: false,
 					}}


### PR DESCRIPTION
Adjusts the plot's legend and margin settings to improve overall clarity and readability.

- Increases the top margin to provide more dedicated space for the legend.
- Lifts the legend's vertical position and slightly reduces its font size for better fit.
- Adds a `tracegroupgap` to the legend, ensuring better spacing if the legend items wrap.