### PR TITLE
Updates comparison plot unavailable message

### DIFF
--- a/hackathon-app/src/components/plots/ComparisonBarPlot.jsx
+++ b/hackathon-app/src/components/plots/ComparisonBarPlot.jsx
@@ -101,19 +101,11 @@ export default function ComparisonBarPlot({
 	// ✅ Remount on slicer change (most reliable)
 	const plotKey = `${level}-${quarter}-${metric}-${geography}`;
 
-	if (noData) {
-		return (
-			<div className='bg-white/70 rounded-2xl shadow p-4'>
-				<div className='text-sm opacity-70'>No comparison data available.</div>
-			</div>
-		);
-	}
-
-	if (isNational) {
+	if (isNational || noData) {
 		return (
 			<div className='bg-white/70 rounded-2xl shadow p-4'>
 				<div className='text-sm opacity-70'>
-					Cannot show comparison for national level.
+					Comparison is available for Country and Region
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Unifies the message displayed when comparison data is not available or not applicable for the selected level.
The new message explicitly states that comparison is available for Country and Region, improving clarity and guiding the user more effectively.
